### PR TITLE
Doc: fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ This repository provides wrappers for [fast BPE](codegen_sources/preprocessing/b
 
 ### Dataset Preprocessing
 
-This repository contains a [pipeline](codegen_sources/preprocessing/preprocess.py) to create programming languages datasets. Now it supports [four datasets modes](https://github.com/fairinternal/CodeGen/tree/master/codegen_sources/preprocessing/dataset_modes):
+This repository contains a [pipeline](codegen_sources/preprocessing/preprocess.py) to create programming languages datasets. Now it supports [four datasets modes](https://github.com/facebookresearch/CodeGen/tree/master/codegen_sources/preprocessing/dataset_modes):
 - Monolingual (ex: Java source code) 
 - Monolingual Functions (ex: Java functions) 
 - Monolingual Obfuscated (ex: Obfuscated Java source code. [Details here])
 - Monolingual Obfuscated Functions (ex: Obfuscated Java functions)
 
-First, download C++ / Java / Python source code from [Google BigQuery](https://cloud.google.com/blog/products/gcp/github-on-bigquery-analyze-all-the-open-source-code). To run our preprocessing pipeline, you need to donwload the raw source code on your machine in a JSON format. A sample of it is given [here](https://github.com/fairinternal/CodeGen/tree/master/data/test_dataset).
+First, download C++ / Java / Python source code from [Google BigQuery](https://cloud.google.com/blog/products/gcp/github-on-bigquery-analyze-all-the-open-source-code). To run our preprocessing pipeline, you need to donwload the raw source code on your machine in a JSON format. A sample of it is given [here](https://github.com/facebookresearch/CodeGen/tree/master/data/test_dataset).
 
 The pipeline does the following:
 - Source code extraction from json (`.json.gz`) and tokenization (`.tok`)
@@ -69,7 +69,7 @@ python -m codegen_sources.preprocessing.preprocess \
 ```
 If you give several languages, the BPE codes and vocab will be learned commonly on these languages , so that you will have a common vocabulary to train one model for several languages. If you do not want that, launch the pipeline on every language separatly. [These tests](codegen_sources/preprocessing/tests/pipeline/test_pipeline.py) test the pipeline on different modes. It will give you an overview of the possible options. 
 
-Also, we provide the BPE codes and vocabulary [here](https://github.com/fairinternal/CodeGen/tree/master/data/bpe/cpp-java-python). These are the codes and vocabulary used for TransCoder and DOBF. They were learned on concatenated C++, Java, and Python data. If you want to use them instead of learning new ones, give the corresponding paths as ```fastbpe_code_path``` and ```fastbpe_vocab_path``` arguments.
+Also, we provide the BPE codes and vocabulary [here](https://github.com/facebookresearch/CodeGen/tree/master/data/bpe/cpp-java-python). These are the codes and vocabulary used for TransCoder and DOBF. They were learned on concatenated C++, Java, and Python data. If you want to use them instead of learning new ones, give the corresponding paths as ```fastbpe_code_path``` and ```fastbpe_vocab_path``` arguments.
 
 In TransCoder and DOBF readmes, we provide the commands to preprocess the respective datasets.
 
@@ -77,7 +77,7 @@ In TransCoder and DOBF readmes, we provide the commands to preprocess the respec
 ## Model
 
 ### Overview
-In this repository, we provide [code](https://github.com/fairinternal/CodeGen/tree/master/codegen_sources/model) to [train](codegen_sources/model/train.py) transformer-based models (code based on [XLM repository](https://github.com/facebookresearch/XLM)). The available training tasks are the following:
+In this repository, we provide [code](https://github.com/facebookresearch/CodeGen/tree/master/codegen_sources/model) to [train](codegen_sources/model/train.py) transformer-based models (code based on [XLM repository](https://github.com/facebookresearch/XLM)). The available training tasks are the following:
 - Masked Language Model (MLM)
 - Causal Language Model (CLM)
 - Supervised Machine translation (MT)
@@ -87,7 +87,7 @@ In this repository, we provide [code](https://github.com/fairinternal/CodeGen/tr
 
 We [evaluate](codegen_sources/model/src/evaluation/evaluator.py) our models with metrics adapted to each task (e.g. computation accuracy and BLEU score for TransCoder, subtoken score for Deobfuscation).
 
-Also, we provide [wrappers](https://github.com/fairinternal/CodeGen/tree/master/codegen_sources/wrappers) to fine-tune and evaluate our models on [CodeXGLUE](https://arxiv.org/pdf/2102.04664.pdf) benchmark.
+Also, we provide [wrappers](https://github.com/facebookresearch/CodeGen/tree/master/codegen_sources/wrappers) to fine-tune and evaluate our models on [CodeXGLUE](https://arxiv.org/pdf/2102.04664.pdf) benchmark.
 
 
 ### Download models


### PR DESCRIPTION
A drive-by change, fixing several broken links by changing the repository name from `github.com/fairinternal` to `github.com/facebookresearch`

Even better option would be to drop `https://github.com/facebookresearch/CodeGen/tree/master/` completely and allow Github to generate relative links, but that may be undesirable in case GH is not the only source code forge used for this codebase.