### PR TITLE
Limited local parallelism across file lines

### DIFF
--- a/codegen_sources/preprocessing/dataset_modes/dataset_mode.py
+++ b/codegen_sources/preprocessing/dataset_modes/dataset_mode.py
@@ -162,7 +162,7 @@ class DatasetMode(Generic[T]):
                     self.extract_from_json_and_tokenize,
                     files,
                     file_langs,
-                    repeat(self.bpe.process_strings)
+                    repeat(self.bpe.process_strings),
                 )
             else:
                 for f, flang in zip(files, file_langs):

--- a/codegen_sources/preprocessing/dataset_modes/dataset_mode.py
+++ b/codegen_sources/preprocessing/dataset_modes/dataset_mode.py
@@ -127,12 +127,9 @@ class DatasetMode(Generic[T]):
         logger.info("")
         logger.info("")
         logger.info("========== Extract and Tokenize ===========")
-        if executor is None:
-            if local_parallelism is None:
-                executor = LocalExecutor(folder=self.folder.joinpath("log"))
-            else:
-                executor = ProcessPoolExecutor(max_workers=local_parallelism)
-
+        if local_parallelism is not None:
+            logger.info(f"Using {local_parallelism} processors.")
+            executor = ProcessPoolExecutor(max_workers=local_parallelism)
         jobs = []
 
         assert any(


### PR DESCRIPTION
This change allow the users to limit the amount of parallelism across line files. Before, the maximum parallelism (cpu count) was used for tokenization. 