### PR TITLE
fix sorting of translations issue

### DIFF
--- a/codegen_sources/test_generation/select_successful_tests.py
+++ b/codegen_sources/test_generation/select_successful_tests.py
@@ -184,7 +184,6 @@ def get_first_success(test_results, language):
     min_successful_len = float("inf")
     for translations_i, result_i in zip(translations, tests_results):
         any_successful = False
-        translations_i = sorted(translations_i, key=lambda x: len(x))
         for translated_code, res in zip(translations_i, result_i):
             if res[0] == "success":
                 if not any_successful:


### PR DESCRIPTION
fixes #56 

The output of select_successful_tests.py seems to often have programs selected that do not pass tests. 

To describe the code in question: In the nested loop here, the outer loop gets two iterables of translations and results that should be of length beam-size. The inner loop then iterates through the translations and results to select the shortest translation that has been successful.

Before the inner loop, there is a step to sort the translations; however, the sorting step sorts only the translations and not the results. As a result, the corresponding results (i.e. success/failure) get scrambled. This edit removes the sorting step. 

Perhaps the sorting step was made in an attempt to exit the inner loop early? An alternative is to sort both the translations and results and exit the inner loop early when a successful result is found. 

Using the following script as a sanity check; I get 499/500 examples that pass after the fix, and the failed example calls a random number generator which explains the "incorrect output." Whereas before the fix, only 267/500 examples passed. 

[test_pairs.py.zip](https://github.com/facebookresearch/CodeGen/files/7807174/test_pairs.py.zip)
