### PR TITLE
getargspec Deprecated since Python 3.5, use `inspect.getfullargspec()`

### DIFF
--- a/codegen_sources/model/src/evaluation/evaluator.py
+++ b/codegen_sources/model/src/evaluation/evaluator.py
@@ -1620,7 +1620,7 @@ class EncDecEvaluator(Evaluator):
         )
         for beam_number, success_for_beam in enumerate(success_for_beam_number):
             scores[
-                "%s_%s-%smt_comp_acc_contrib_beam_%i"
+                "%s_%s-%s_mt_comp_acc_contrib_beam_%i"
                 % (data_set + prefix, lang1, lang2, beam_number)
             ] = (
                 100.0

--- a/codegen_sources/model/src/optim.py
+++ b/codegen_sources/model/src/optim.py
@@ -312,7 +312,9 @@ def get_optimizer(parameters, s):
         raise Exception('Unknown optimization method: "%s"' % method)
 
     # check that we give good parameters to the optimizer
-    expected_args = inspect.getargspec(optim_fn.__init__)[0]
+    (args, _varargs, _varkw, _defaults, kwonlyargs, _kwonlydefaults, _annotations) \
+        = inspect.getfullargspec(optim_fn.__init__)
+    expected_args = args + kwonlyargs
     assert expected_args[:2] == ["self", "params"]
     if not all(k in expected_args[2:] for k in optim_params.keys()):
         raise Exception(

--- a/docs/dobf.md
+++ b/docs/dobf.md
@@ -89,7 +89,7 @@ python train.py
 --lgs 'java-python' \
 --max_vocab 64000 \
 --gelu_activation true\
---roberta_mode true
+--tokenization_mode fastbpe \
 --max_len 512 \ 
 
 #optimization
@@ -136,7 +136,7 @@ python train.py
 --lgs 'python_dictionary-python_obfuscated-java_dictionary-java_obfuscated' \
 --max_vocab 64000 \
 --gelu_activation true \
---roberta_mode true \ 
+--tokenization_mode fastbpe \
  
 ## model reloading
 --reload_model '<PATH_TO_MLM_MODEL>,' \
@@ -200,7 +200,7 @@ python train.py
 --lgs 'java_sa-python_sa'  \
 --max_vocab 64000 \
 --gelu_activation true \
---roberta_mode true   \ 
+--tokenization_mode fastbpe \
 --max_len 512 \ 
 
 ## model reloading

--- a/docs/transcoder.md
+++ b/docs/transcoder.md
@@ -107,7 +107,7 @@ python codegen_sources/model/train.py
 --lgs 'cpp-java-python' \
 --max_vocab 64000 \
 --gelu_activation false \
---roberta_mode false \
+--tokenization_mode fastbpe \
 --max_len 512 \
 
 #optimization
@@ -153,7 +153,7 @@ python codegen_sources/model/train.py
 --lgs 'cpp_sa-java_sa-python_sa'  \
 --max_vocab 64000 \
 --gelu_activation false \
---roberta_mode false   \ 
+--tokenization_mode fastbpe \
 --max_len 512 \
 
 ## model reloading
@@ -206,7 +206,7 @@ python codegen_sources/model/train.py \
 --lgs 'cpp_sa-java_sa-python_sa'  \
 --max_vocab 64000 \
 --gelu_activation false \
---roberta_mode false  \
+roberta_mode
 --amp 2  \
 --fp16 true  \
 --tokens_per_batch 3000  \

--- a/docs/transcoder.md
+++ b/docs/transcoder.md
@@ -206,7 +206,7 @@ python codegen_sources/model/train.py \
 --lgs 'cpp_sa-java_sa-python_sa'  \
 --max_vocab 64000 \
 --gelu_activation false \
-roberta_mode
+--tokenization_mode fastbpe \
 --amp 2  \
 --fp16 true  \
 --tokens_per_batch 3000  \


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "/home/pana/github.com/facebookresearch/CodeGen/codegen_sources/model/train.py", line 1020, in <module>
    main(params)
  File "/home/pana/github.com/facebookresearch/CodeGen/codegen_sources/model/train.py", line 872, in main
    trainer = EncDecTrainer(encoder, decoder, data, params)
  File "/home/pana/github.com/facebookresearch/CodeGen/codegen_sources/model/src/trainer.py", line 1350, in __init__
    super().__init__(data, params, self.MODEL_NAMES)
  File "/home/pana/github.com/facebookresearch/CodeGen/codegen_sources/model/src/trainer.py", line 111, in __init__
    self.set_optimizers()
  File "/home/pana/github.com/facebookresearch/CodeGen/codegen_sources/model/src/trainer.py", line 305, in set_optimizers
    self.optimizers["model"] = get_optimizer(
  File "/home/pana/github.com/facebookresearch/CodeGen/codegen_sources/model/src/optim.py", line 315, in get_optimizer
    expected_args = inspect.getargspec(optim_fn.__init__)[0]
  File "/usr/lib/python3.10/inspect.py", line 1245, in getargspec
    raise ValueError("Function has keyword-only parameters or annotations"
ValueError: Function has keyword-only parameters or annotations, use inspect.signature() API which can support them
```