### PR TITLE
fix the part that reloads the model using CAPE1d().

### DIFF
--- a/codegen_sources/model/src/model/__init__.py
+++ b/codegen_sources/model/src/model/__init__.py
@@ -343,7 +343,8 @@ def reload_transformer(
     clean_model_state_dict(reloaded, model_type, model_number)
     reload_word_embeddings(reloaded, dico, model_type)
     reload_lang_embeddings(reloaded, params, model_type)
-    reload_position_embeddings(reloaded, model, model_type)
+    if not params.cape_embeddings:
+        reload_position_embeddings(reloaded, model, model_type)
 
     # if the model is a decoder
     if hasattr(model, "encoder_attn"):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ki-nismr/C2OpenMP/m2/CodeGen/codegen_sources/model/train.py", line 1064, in <module>
    main(params)
  File "/home/ki-nismr/C2OpenMP/m2/CodeGen/codegen_sources/model/train.py", line 902, in main
    encoder, decoder = build_model(params, data["dico"])
  File "/home/ki-nismr/anaconda3/envs/codegen_3_10/lib/python3.10/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/ki-nismr/C2OpenMP/m2/CodeGen/codegen_sources/model/src/model/__init__.py", line 246, in build_model
    reload_transformer(params, enc_path, dico, encoder, "encoder", gpu=gpu)
  File "/home/ki-nismr/C2OpenMP/m2/CodeGen/codegen_sources/model/src/model/__init__.py", line 347, in reload_transformer
    reload_position_embeddings(reloaded, model, model_type)
  File "/home/ki-nismr/C2OpenMP/m2/CodeGen/codegen_sources/model/src/model/__init__.py", line 515, in reload_position_embeddings
    current_size = encoder.position_embeddings.weight.size()[0]
  File "/home/ki-nismr/anaconda3/envs/codegen_3_10/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1207, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'CAPE1d' object has no attribute 'weight'
```

Sorry if I made a mistake in my first pull request.
When I try to reload a model using CAPE1d, I get the above error.
I think reload_position_embeddings() in codegen_sources/model/src/model/__init__.py is not necessary when using CAPE1d().
Please confirm this.